### PR TITLE
Add a taint to the dpu host node when heartbeat check fail

### DIFF
--- a/helm/ovn-kubernetes-dpf/templates/common.yaml
+++ b/helm/ovn-kubernetes-dpf/templates/common.yaml
@@ -30,11 +30,14 @@ rules:
 - apiGroups: [""]
   resources:
   - namespaces
-  - nodes
   - pods
   - services
   - endpoints
   verbs: [ "get", "list", "watch" ]
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs: [ "get", "list", "watch", "patch", "update" ]
 - apiGroups: ["coordination.k8s.io"]
   resources:
   - leases


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
fixes #6 
 Informs the Kubernetes scheduler and other controllers that the node should be avoided for pod placement unless the pod explicitly tolerates the taint when the heartbeat fails. This, because the dpu node network is likely faulty.

We use a well known taint `node.kubernetes.io/network-unavailable`, so that critical daemonsets can still tolerate it.

We do not evict pods.

Once the heartbeat is successful again, the taint is removed.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
unit test included.

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note

```
