### PR TITLE
feat: use VTEP_CIDR in external mode of cniprovisioner

### DIFF
--- a/helm/ovn-kubernetes-dpf/templates/dpu-manifests.yaml
+++ b/helm/ovn-kubernetes-dpf/templates/dpu-manifests.yaml
@@ -288,14 +288,14 @@ spec:
         - name: GATEWAY_DISCOVERY_NETWORK
           value: {{ default "" .Values.dpuManifests.gatewayDiscoveryNetwork | quote }}
         {{- else }}
-        - name: VTEP_CIDR
-          value: {{ default "" .Values.dpuManifests.vtepCIDR | quote }}
         - name: OVN_MTU
           valueFrom:
             configMapKeyRef:
               name: {{ include "ovn-kubernetes.fullname" . }}-config
               key: mtu
         {{- end }}
+        - name: VTEP_CIDR
+          value: {{ default "" .Values.dpuManifests.vtepCIDR | quote }}
         - name: HOST_CIDR
           value: {{ default "" .Values.dpuManifests.hostCIDR | quote }}
         volumeMounts:


### PR DESCRIPTION
In order to apply source routing, we now need to ask the user to provide `vtepCIDR` even when the we use the cniprovisioner in external IPAM mode (OVN only use case for DPF). This PR takes care of that.